### PR TITLE
Logging Improvements

### DIFF
--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -244,7 +244,7 @@ class Cloud:
         try:
             utils.run_bashscript_repeat(cmd, 3, 3, verbose=self.log)
         except Exception as e:
-            logging.error("Remote Upload Failed   for this file")
+            logging.error("Remote Upload Failed for this file")
             logging.error("Exception: %s", e)
 
     def remote_upload_output_s3(self, host_node, prefix):

--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -7,8 +7,6 @@ import logging
 
 class Cloud:
 
-    log = False
-
     subnet_id = 'subnet-0b1a206e'   # ec2 instances will be launched into this subnet (in a vpc)
     cluster = 'default'             # for ecs, which cluster to use
     mainkeyname = 'nextpair'        # when creating ec2 instances, the root ssh key to use
@@ -19,8 +17,8 @@ class Cloud:
     # the idempotency of the request.
     network_interface_id = 'eni - b2acd4d4'
 
-    def __init__(self, log):
-        self.log = log
+    def __init__(self):
+        pass
 
     def sync_experiment(self, remote):
         """
@@ -30,7 +28,7 @@ class Cloud:
         print ("\n....... Use remote-sync-experiment.sh to rsync relevant folders.")
 
         cmd = "../remote/remote-sync-experiment.sh " + remote.host_key_user_variables()
-        utils.run_bashscript_repeat(cmd, 15, 6, verbose=self.log)
+        utils.run_bashscript_repeat(cmd, 15, 6)
 
     def remote_download_output(self, prefix, host_node):
         """ Download /output/prefix folder from remote storage (s3) to remote machine. 
@@ -43,7 +41,7 @@ class Cloud:
                "files) with prefix = " + prefix + ", to remote machine.")
 
         cmd = "../remote/remote-download-output.sh " + " " + prefix + " " + host_node.host_key_user_variables()
-        utils.run_bashscript_repeat(cmd, 15, 6, verbose=self.log)
+        utils.run_bashscript_repeat(cmd, 15, 6)
 
     def remote_docker_launch_compute(self, host_node):
         """ Assumes there exists a private key for the given ec2 instance, at keypath """
@@ -57,7 +55,7 @@ class Cloud:
             ./run-in-docker.sh -d
         '''.format(host_node.remote_variables_file)
 
-        return utils.remote_run(host_node, commands, verbose=self.log)
+        return utils.remote_run(host_node, commands)
 
     def ecs_run_task(self, task_name):
         """ Run task 'task_name' and return the Task ARN """
@@ -71,8 +69,7 @@ class Cloud:
             startedBy='pyScript'
         )
 
-        if self.log:
-            print("LOG: ", response)
+        logging.debug("LOG: " + response)
 
         length = len(response['failures'])
         if length > 0:
@@ -100,8 +97,7 @@ class Cloud:
             reason='pyScript said so!'
         )
 
-        if self.log:
-            logging.debug("LOG: ", response)
+        logging.debug("LOG: " + response)
 
     def ec2_start_from_instanceid(self, instance_id):
         """
@@ -114,8 +110,7 @@ class Cloud:
         instance = ec2.Instance(instance_id)
         response = instance.start()
 
-        if self.log:
-            print("LOG: Start response: ", response)
+        print("LOG: Start response: " + response)
 
         instance_id = instance.instance_id
 
@@ -184,8 +179,7 @@ class Cloud:
 
         instance_id = instance[0].instance_id
 
-        if self.log:
-            logging.debug("Instance launched ", instance_id)
+        logging.debug("Instance launched %s", instance_id)
 
         # set name
         response = ec2.create_tags(
@@ -201,8 +195,8 @@ class Cloud:
             ]
         )
 
-        logging.debug("Set Name tag on instanceid: ", instance_id)
-        logging.debug("Response is: ", response)
+        logging.debug("Set Name tag on instanceid: %s", instance_id)
+        logging.debug("Response is: %s", response)
 
         ips = self.ec2_wait_till_running(instance_id)
         return ips, instance_id
@@ -242,14 +236,14 @@ class Cloud:
         cmd = "../remote/remote-upload-runfilename.sh " + " " + prefix + " " + dest_name \
               + host_node.host_key_user_variables()
         try:
-            utils.run_bashscript_repeat(cmd, 3, 3, verbose=self.log)
+            utils.run_bashscript_repeat(cmd, 3, 3)
         except Exception as e:
             logging.error("Remote Upload Failed for this file")
             logging.error("Exception: %s", e)
 
     def remote_upload_output_s3(self, host_node, prefix):
         cmd = "../remote/remote-upload-output.sh " + prefix + " " + host_node.host_key_user_variables()
-        utils.run_bashscript_repeat(cmd, 3, 3, verbose=self.log)
+        utils.run_bashscript_repeat(cmd, 3, 3)
 
     def upload_folder_s3(self, bucket_name, key, source_folderpath):
 

--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -254,11 +254,11 @@ class Cloud:
     def upload_folder_s3(self, bucket_name, key, source_folderpath):
 
         if not os.path.exists(source_folderpath):
-            print("WARNING: folder does not exist, cannot upload: " + source_folderpath)
+            logging.warning("folder does not exist, cannot upload: " + source_folderpath)
             return
 
         if not os.path.isdir(source_folderpath):
-            print("WARNING: path is not a folder, cannot upload: " + source_folderpath)
+            logging.warning("path is not a folder, cannot upload: " + source_folderpath)
             return
 
         for root, dirs, files in os.walk(source_folderpath):

--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -101,7 +101,7 @@ class Cloud:
         )
 
         if self.log:
-            print("LOG: ", response)
+            logging.debug("LOG: ", response)
 
     def ec2_start_from_instanceid(self, instance_id):
         """
@@ -144,7 +144,7 @@ class Cloud:
             instance_type = 'r3.xlarge'     # 30.5
             ram_allocated = 30.5
         else:
-            print("ERROR: cannot create an ec2 instance with that much RAM")
+            logging.error("cannot create an ec2 instance with that much RAM")
             exit(1)
 
         print ("\n............. RAM to be allocated: " + str(ram_allocated) + " GB RAM")
@@ -185,7 +185,7 @@ class Cloud:
         instance_id = instance[0].instance_id
 
         if self.log:
-            print("Instance launched ", instance_id)
+            logging.debug("Instance launched ", instance_id)
 
         # set name
         response = ec2.create_tags(
@@ -272,7 +272,7 @@ class Cloud:
     def upload_file_s3(bucket_name, key, source_filepath):
 
         if not os.path.exists(source_filepath):
-            print("WARNING: file does not exist, cannot upload: " + source_filepath)
+            logging.warning("file does not exist, cannot upload: " + source_filepath)
             return
 
         s3 = boto3.resource('s3')
@@ -288,7 +288,7 @@ class Cloud:
                 exists = False
 
         if not exists:
-            print("WARNING: s3 bucket " + bucket_name + " does not exist, creating it now.")
+            logging.warning("s3 bucket " + bucket_name + " does not exist, creating it now.")
             s3.create_bucket(Bucket=bucket_name)
 
         print(" ... file = " + source_filepath + ", to bucket = " + bucket_name + ", key = " + key)

--- a/scripts/run-framework/agief_experiment/compute.py
+++ b/scripts/run-framework/agief_experiment/compute.py
@@ -93,7 +93,7 @@ class Compute:
                         break
             except KeyError:
                 logging.error("KeyError Exception")
-                logging.error("WARNING: trying to access a keypath in config object, that DOES NOT exist!")
+                logging.error("Trying to access a keypath in config object, that DOES NOT exist!")
             except requests.exceptions.ConnectionError:
                 logging.error("Oops, ConnectionError exception")
                 connection_error_count += 1
@@ -115,7 +115,7 @@ class Compute:
         print("\n....... Import experiment")
 
         if not is_entity_file and not is_data_files:
-            print("        WARNING: no input files specified (that may be intentional)")
+            logging.warning("No input files specified (that may be intentional)")
             return
 
         print("     Input files: ")
@@ -372,7 +372,7 @@ class Compute:
             version = None
 
             if not is_suppress_console_output:
-                print("Error connecting to agief to retrieve the version.")
+                logging.error("Error connecting to agief to retrieve the version.")
 
         return version
 
@@ -400,7 +400,7 @@ class Compute:
         if cloud and self.remote():
             if use_ecs:
                 # Using ECS - the elastic container service
-                print("launching Compute on AWS-ECS")
+                print("Launching Compute on AWS-ECS")
                 if not ecs_task_name:
                     raise ValueError("ERROR: you must specify a Task Name to run on aws-ecs")
                 task_arn = cloud.ecs_run_task(ecs_task_name)
@@ -412,8 +412,8 @@ class Compute:
                     self.container_id = output[-4].rstrip()
                     print("Docker Container ID: " + self.container_id)
         else:
-            print("launching Compute locally")
-            print("NOTE: generating run_stdout.log and run_stderr.log (in the current folder)")
+            print("Launching Compute locally")
+            print("NOTE: Generating run_stdout.log and run_stderr.log (in the current folder)")
 
             if main_class:
                 cmd = "%s node.properties %s %s" % (
@@ -457,7 +457,7 @@ class Compute:
             if self.container_id:
                 utils.remote_run(self.host_node, 'docker stop ' + self.container_id, True)
             else:
-                print("WARNING: Docker did not shut down, could not locate container id")
+                logging.warning("Docker did not shut down, could not locate container id")
         else:
             # stops local docker
             utils.docker_stop()

--- a/scripts/run-framework/agief_experiment/compute.py
+++ b/scripts/run-framework/agief_experiment/compute.py
@@ -92,8 +92,7 @@ class Compute:
                                 value) + ".")
                         break
             except KeyError:
-                logging.error("KeyError Exception")
-                logging.error("Trying to access a keypath in config object, that DOES NOT exist!")
+                logging.warning("KeyError Exception: Trying to access a keypath in config object, that DOES NOT exist!")
             except requests.exceptions.ConnectionError:
                 logging.error("Oops, ConnectionError exception")
                 connection_error_count += 1

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -46,7 +46,7 @@ class Experiment:
                                                                                ExperimentUtils.agi_exp_home)
 
             if not os.path.isfile(prefix_filepath) or not os.path.exists(prefix_filepath):
-                print("WARNING ****   no prefix.txt file could be found, using the default root entity name: "
+                logging.warning("no prefix.txt file could be found, using the default root entity name: "
                       "'experiment'")
                 return None
 
@@ -113,10 +113,10 @@ class Experiment:
                     param_path = config_exp['value'][reporting_path_key]
                     report = dpath.util.get(config, 'value.' + param_path, '.')
                 else:
-                    print("WARNING: No reporting entity config path found in experiment config.")
+                    logging.warning("No reporting entity config path found in experiment config.")
             except KeyError:
-                print("KeyError Exception")
-                print("WARNING: trying to access path '" + param_path + "' at config.value, but it DOES NOT exist!")
+                logging.error("KeyError Exception: trying to access path '" + 
+                param_path + "' at config.value, but it DOES NOT exist!")
             if report is None:
                 print("\n================================================")
                 print("Reporting Entity Config:")
@@ -128,7 +128,7 @@ class Experiment:
                 print(report)
                 print("================================================\n")
         else:
-            print("WARNING: No reportingEntityName has been specified in Experiment config.")
+            logging.warning("No reportingEntityName has been specified in Experiment config.")
 
     def entity_with_prefix(self, entity_name):
         if self.prefix() is None or self.prefix() == "":
@@ -252,7 +252,7 @@ class Experiment:
         """
 
         if len(val_sweepers) == 0:
-            print("WARNING: in_parameter_set: there are no counters to use to increment the parameter set.")
+            logging.warning("there are no counters to use to increment the parameter set.")
             print("         Returning without any action. This may have undesirable consequences.")
             return True, ""
 
@@ -267,7 +267,7 @@ class Experiment:
 
             if overflowed:
                 if args.logging:
-                    print("LOG: Sweeping has concluded for this sweep-set, due to the parameter: " +
+                    logging.debug("LOG: Sweeping has concluded for this sweep-set, due to the parameter: " +
                           val_sweeper['entity-name'] + '.' + val_sweeper['param-path'])
                 reset = True
                 break
@@ -280,14 +280,14 @@ class Experiment:
             val_series.next_val()
 
         if len(sweep_param_vals) == 0:
-            print("WARNING: no parameters were changed.")
+            logging.warning("no parameters were changed.")
 
         if args.logging:
             if len(sweep_param_vals):
-                print("LOG: Parameter sweep: ", sweep_param_vals)
+                logging.debug("LOG: Parameter sweep: ", sweep_param_vals)
 
         if reset is False and len(sweep_param_vals) == 0:
-            print("Error: inc_parameter_set() indeterminate state, reset is False, but parameter_description indicates "
+            logging.error("indeterminate state, reset is False, but parameter_description indicates "
                   "no parameters have been modified. If there is no sweep to conduct, reset should be True.")
             exit(1)
 
@@ -441,8 +441,8 @@ class Experiment:
             output_data_filepath = utils.match_file_by_name(folder_path, 'data')
 
             if output_data_filepath is None:
-                print "WARNING: No data file found. This should only happen if you are running remote via ssh, " \
-                      "and exporting data by saving on compute."
+                logging.warning("No data file found. This should only happen if you are running remote via ssh, " \
+                      "and exporting data by saving on compute.")
             else:
                 # Compress data file
                 utils.compress_file(output_data_filepath)

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -24,11 +24,10 @@ class Experiment:
     TEMPLATE_PREFIX = "SPAGHETTI"
     PREFIX_DELIMITER = "--"
 
-    def __init__(self, log, debug_no_run, launch_mode, exps_file):
+    def __init__(self, debug_no_run, launch_mode, exps_file):
         self.exps_file = exps_file
         self.debug_no_run = debug_no_run
         self.launch_mode = launch_mode
-        self.log = log
 
         self.experiment_utils = ExperimentUtils(exps_file)
 

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -115,7 +115,7 @@ class Experiment:
                 else:
                     logging.warning("No reporting entity config path found in experiment config.")
             except KeyError:
-                logging.error("KeyError Exception: trying to access path '" + 
+                logging.warning("KeyError Exception: trying to access path '" +
                 param_path + "' at config.value, but it DOES NOT exist!")
             if report is None:
                 print("\n================================================")

--- a/scripts/run-framework/agief_experiment/experimentutils.py
+++ b/scripts/run-framework/agief_experiment/experimentutils.py
@@ -29,7 +29,7 @@ class ExperimentUtils:
         variables_file = self.variables_filepath()
 
         if variables_file == "" or variables_file is None:
-            print "WARNING: unable to locate variables file."
+            logging.warning("unable to locate variables file.")
 
         logging.debug("experiment:filepath_from_env_variable: variables file = %s", variables_file)
 
@@ -183,8 +183,8 @@ class ExperimentUtils:
             base_filepath = self.inputfile_base(base_filename)
 
             if not os.path.isfile(base_filepath):
-                print "ERROR: create_input_files(): The file does not exist" + base_filepath + \
-                      "\nCANNOT CONTINUE."
+                logging.error("The file does not exist" + base_filepath + \
+                      "\nCANNOT CONTINUE.")
                 exit(1)
 
             # get the containing folder, and it's parent folder

--- a/scripts/run-framework/agief_experiment/utils.py
+++ b/scripts/run-framework/agief_experiment/utils.py
@@ -65,12 +65,11 @@ def cleanpath(path, filename):
     return file_path
 
 
-def run_bashscript_repeat(cmd, max_repeats, wait_period, verbose=False):
+def run_bashscript_repeat(cmd, max_repeats, wait_period):
     """ Run a shell command repeatedly until exit status shows success.
     Run command 'cmd' a maximum of 'max_repeats' times and wait 'wait_period' between attempts. """
 
-    if verbose:
-        print "run_bashscript_repeat, running cmd = " + cmd
+    logging.debug("running cmd = " + cmd)
 
     success = False
     exit_status = 0
@@ -82,21 +81,18 @@ def run_bashscript_repeat(cmd, max_repeats, wait_period, verbose=False):
                                  executable="/bin/bash")
 
         output, error = child.communicate()  # get the outputs. NOTE: This will block until shell command returns.
-
         exit_status = child.returncode
 
-        if verbose:
-            print "Stdout: " + output
-            print "Exit status: " + str(exit_status)
-
-        print "utils.run_bashscript_repeat - stderr: " + error
+        logging.debug("Stdout: " + output)
+        logging.error("Stderr: " + error)
+        logging.debug("Exit status: " + str(exit_status))
 
         if exit_status == 0:
             success = True
             break
 
-        print "Run bash script was unsuccessful on attempt " + str(i)
-        print "Wait " + str(wait_period) + ", and try again."
+        logging.warning("Run bash script was unsuccessful on attempt " + str(i))
+        logging.debug("Wait " + str(wait_period) + ", and try again.")
 
         time.sleep(wait_period)
 
@@ -269,7 +265,7 @@ def docker_stop(container_id=None):
     return exit_status
 
 
-def remote_run(host_node, cmd, verbose=False):
+def remote_run(host_node, cmd):
     """
     Runs a set of commands on a remote machine over SSH using paramiko.
 
@@ -277,8 +273,7 @@ def remote_run(host_node, cmd, verbose=False):
     :param commands: The commands to be executed
     :param verbose: Set to True to display the stdout
     """
-    if verbose:
-        print("remote_run, running cmd = " + cmd)
+    logging.debug("running cmd = " + cmd)
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -302,8 +297,7 @@ def remote_run(host_node, cmd, verbose=False):
     stdin.write(cmd)
     output = stdout.readlines()
 
-    if verbose:
-        print("Stdout: " + ''.join(output))
+    logging.debug("Stdout: " + ''.join(output))
 
     stdout.close()
     stdin.close()

--- a/scripts/run-framework/agief_experiment/utils.py
+++ b/scripts/run-framework/agief_experiment/utils.py
@@ -304,3 +304,22 @@ def remote_run(host_node, cmd):
     ssh.close()
 
     return output
+
+def logger_level(level):
+    """
+    Map the specified level to the numerical value level for the logger
+
+    :param level: Logging level from command argument
+    """
+    try:
+        level = level.lower()
+    except AttributeError:
+        level = ""
+
+    return {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warning': logging.WARNING,
+        'error': logging.ERROR,
+        'critical': logging.CRITICAL
+    }.get(level, logging.WARNING)

--- a/scripts/run-framework/agief_experiment/utils.py
+++ b/scripts/run-framework/agief_experiment/utils.py
@@ -117,7 +117,7 @@ def check_validity(files):
             file_paths.append(f)
         else:
             is_valid = False
-            print "ERROR: check_validity(), this file is not valid: " + f
+            logging.error("this file is not valid: " + f)
             break
 
     return is_valid
@@ -135,7 +135,7 @@ def compress_file(source_filepath):
         zipf.write(source_filepath)
         zipf.close()
     else:
-        print "ERROR: compress_file(), this file is not valid: " + source_filepath
+        logging.error("this file is not valid: " + source_filepath)
 
 
 def compress_folder_contents(source_path):
@@ -151,7 +151,7 @@ def compress_folder_contents(source_path):
                 filepath = os.path.join(root, filename)
                 compress_file(filepath)
     else:
-        print "ERROR: compress_file_in_folder(), this folder is not valid: " + source_path
+        logging.error("this folder is not valid: " + source_path)
 
 
 def match_file_by_name(source_path, name):
@@ -170,9 +170,9 @@ def match_file_by_name(source_path, name):
                 ret = os.path.abspath(root + "/" + matching_files[0])
                 return ret
             else:
-                print "WARNING: match_file_by_name(), no matching files found in: " + source_path
+                logging.warning("no matching files found in: " + source_path)
     else:
-        print "WARNING: match_file_by_name(), this folder is not valid: " + source_path
+        logging.warning("this folder is not valid: " + source_path)
 
     return None
 
@@ -196,9 +196,9 @@ def move_file(source_filepath, dest_path, create_dest=False):
             # Move file from source to destination
             os.rename(source_filepath, dest_path + "/" + parsed_filepath[1])
         else:
-            print "ERROR: move_file(), the destination folder is not valid: " + dest_path
+            logging.error("the destination folder is not valid: " + dest_path)
     else:
-        print "ERROR: move_file(), the source file path is not valid: " + source_filepath
+        logging.error("the source file path is not valid: " + source_filepath)
 
 
 def get_entityfile_config(entity):

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -163,15 +163,13 @@ def check_args(args, compute_node):
 def main():
 
     # setup logging
-    # logger = logging.getLogger('root')
-    # log_format = "[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
-    # logging.basicConfig(format=log_format)
-    # logger.setLevel(logging.INFO)
+    log_format = "[%(filename)s:%(lineno)s - %(funcName)20s() -  ] %(message)s"
+    logging.basicConfig(format=log_format, level=logging.INFO)
 
     logging.info("------------------------------------------")
     logging.info("----          run-framework           ----")
     logging.info("------------------------------------------")
-    logging.info ("Python Version: " + sys.version)
+    logging.debug ("Python Version: " + sys.version)
 
     # Record experiment start time
     exp_start_time = datetime.now()

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -163,13 +163,12 @@ def check_args(args, compute_node):
 def main():
 
     # setup logging
-    log_format = "[%(filename)s:%(lineno)s - %(funcName)20s() -  ] %(message)s"
+    log_format = "[%(filename)s:%(lineno)s - %clas%(funcName)s() - %(levelname)s] %(message)s"
     logging.basicConfig(format=log_format, level=logging.INFO)
 
-    logging.info("------------------------------------------")
-    logging.info("----          run-framework           ----")
-    logging.info("------------------------------------------")
-    logging.debug ("Python Version: " + sys.version)
+    print("------------------------------------------")
+    print("----          run-framework           ----")
+    print("------------------------------------------")
 
     # Record experiment start time
     exp_start_time = datetime.now()
@@ -177,6 +176,7 @@ def main():
     args = setup_arg_parsing()
     if args.logging:
         logging.debug("Arguments: ", args)
+        logging.debug ("Python Version: " + sys.version)
 
     exps_file = args.exps_file if args.exps_file else ""
     experiment = Experiment(args.logging, args.debug_no_run, LaunchMode.from_args(args), exps_file)
@@ -271,7 +271,7 @@ def main():
         logging.error(e)
 
         # Shutdown the Docker container
-        logging.info("Attempting to shutdown Docker container...")
+        print("Attempting to shutdown Docker container...")
         if host_node.remote() and compute_node.container_id:
             utils.remote_run(host_node, 'docker stop ' + compute_node.container_id, True)
         elif not host_node.remote() and not args.no_docker:
@@ -294,7 +294,7 @@ def main():
 
     # Log the experiment runtime in d:h:m:s:ms format
     exp_runtime = utils.format_timedelta(exp_end_time - exp_start_time)
-    logging.info("Experiment finished in %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
+    print("Experiment finished in %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
 
     if failed:
         exit(1)

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -12,7 +12,7 @@ from agief_experiment.experiment import Experiment
 from agief_experiment.launchmode import LaunchMode
 from agief_experiment import utils
 
-help_generic = """
+HELP_GENERIC = """
 run-framework.py allows you to run each step of the AGIEF (AGI Experimental Framework), locally and on AWS.
 Each step can be toggled with a parameter prefixed with 'step'. See parameter list for description of parameters.
 As with all scripts that are part of AGIEF, the environment variables in VARIABLES_FILES are used.
@@ -30,44 +30,51 @@ Assumptions:
 
 
 def setup_arg_parsing():
+    """
+    Parse the commandline arguments
+    """
     import argparse
     from argparse import RawTextHelpFormatter
 
-    parser = argparse.ArgumentParser(description=help_generic, formatter_class=RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(description=HELP_GENERIC, formatter_class=RawTextHelpFormatter)
 
     # generate input files from the java experiment description
     parser.add_argument('--step_gen_input', dest='main_class', required=False,
                         help='Generate input files for experiments, then exit. '
-                             'The value is the Main class to run, that defines the experiment, '
-                             'before exporting the experimental input files entities.json and data.json. ')
+                             'The value is the Main class to run, that defines '
+                             'the experiment, before exporting the experimental '
+                             'input files entities.json and data.json. ')
 
     # main program flow
     parser.add_argument('--step_remote', dest='remote_type',
-                        help='Run Compute on remote machine. This parameter can specify "simple" or "aws". '
+                        help='Run Compute on remote machine. This parameter can '
+                             'specify "simple" or "aws". '
                              'If "AWS", then launch remote machine on AWS '
                              '(then --instanceid or --amiid needs to be specified).'
                              'Requires setting key path with --ssh_keypath'
                              '(default= % (default)s)')
     parser.add_argument('--exps_file', dest='exps_file', required=False,
-                        help='Run experiments, defined in the file that is set with this parameter.'
-                             'Filename is within AGI_RUN_HOME that defines the '
-                             'experiments to run (with parameter sweeps) in json format (default=%(default)s).')
+                        help='Run experiments, defined in the file that is set '
+                             'with this parameter. Filename is within '
+                             'AGI_RUN_HOME that defines the experiments to run '
+                             '(with parameter sweeps) in json format (default=%(default)s).')
     parser.add_argument('--step_sync', dest='sync', action='store_true',
                         help='Sync the code and run folder. Copy from local machine to remote. '
                              'Requires setting --step_remote and key path with --ssh_keypath')
     parser.add_argument('--step_sync_s3_prefix', dest='sync_s3_prefix', required=False,
-                        help='Sync output files. Download relevant output '
-                             'files from a previous phase determined by prefix, to the remote machine.'
+                        help='Sync output files. Download relevant output files '
+                             'from a previous phase determined by prefix, to the remote machine.'
                              'Requires setting --step_remote and key path with --ssh_keypath')
     parser.add_argument('--step_compute', dest='launch_compute', action='store_true',
                         help='Launch the Compute node.')
     parser.add_argument('--step_shutdown', dest='shutdown', action='store_true',
-                        help='Shutdown instances and Compute (if --launch_per_session) after other stages.')
+                        help='Shutdown instances and Compute '
+                             '(if --launch_per_session) after other stages.')
     parser.add_argument('--step_export', dest='export', action='store_true',
                         help='Export entity tree and data at the end of each experiment.')
     parser.add_argument('--step_export_compute', dest='export_compute', action='store_true',
-                        help='Compute should export entity tree and data at the end of each experiment '
-                             '- i.e. saved on the Compute node.')
+                        help='Compute should export entity tree and data at '
+                             'the end of each experiment - i.e. saved on the Compute node.')
     parser.add_argument('--step_upload', dest='upload', action='store_true',
                         help='Upload exported entity tree and data at the end of each experiment.')
     parser.add_argument('--DEBUG-NO-RUN', dest='debug_no_run', action='store_true',
@@ -76,37 +83,40 @@ def setup_arg_parsing():
     # how to reach the Compute node
     parser.add_argument('--host', dest='host', required=False,
                         help='Host where the Compute node will be running (default=%(default)s). '
-                             'THIS IS IGNORED IF RUNNING ON AWS (in which case the IP of the instance '
-                             'specified by the Instance ID is used)')
+                             'THIS IS IGNORED IF RUNNING ON AWS (in which case '
+                             'the IP of the instance specified by the Instance ID is used)')
     parser.add_argument('--port', dest='port', required=False,
                         help='Port where the Compute node will be running (default=%(default)s).')
     parser.add_argument('--user', dest='user', required=False,
-                        help='If remote, the "user" on the remote Compute node (default=%(default)s).')
+                        help='If remote, the "user" on the remote '
+                             'Compute node (default=%(default)s).')
     parser.add_argument('--ssh_port', dest='ssh_port', required=False,
-                        help='Which port to use for ssh when communicating with remote machine (default=%(default)s).')
+                        help='Which port to use for ssh when communicating '
+                             'with remote machine (default=%(default)s).')
     parser.add_argument('--remote_variables_file', dest='remote_variables_file', required=False,
-                        help='If remote, the path to the remote VARIABLES_FILE to use on the remote Compute node '
-                             '(default=%(default)s).')
+                        help='If remote, the path to the remote VARIABLES_FILE '
+                             'to use on the remote Compute node (default=%(default)s).')
 
     # launch mode
     parser.add_argument('--launch_per_session', dest='launch_per_session', action='store_true',
-                        help='Compute node is launched once at the start (and shutdown at the end if you use '
+                        help='Compute node is launched once at the start '
+                             '(and shutdown at the end if you use '
                              '--step_shutdown. Otherwise, it is launched and shut per experiment.')
 
     parser.add_argument('--no_docker', dest='no_docker', action='store_true',
-                        help='If set, then DO NOT launch in a docker container. Applies to LOCAL usage only. '
-                             '(default=%(default)s). ')
+                        help='If set, then DO NOT launch in a docker container. '
+                             'Applies to LOCAL usage only. (default=%(default)s). ')
 
     # aws/remote details
     parser.add_argument('--instanceid', dest='instanceid', required=False,
-                        help='Instance ID of the ec2 container instance - to start an ec2 instance, use this OR ami id,'
-                             ' not both.')
+                        help='Instance ID of the ec2 container instance - to '
+                             'start an ec2 instance, use this OR ami id, not both.')
     parser.add_argument('--amiid', dest='amiid', required=False,
-                        help='AMI ID for new ec2 instances - to start an ec2 instance, use this OR instance id, not'
-                             ' both.')
+                        help='AMI ID for new ec2 instances - to start an ec2 '
+                             'instance, use this OR instance id, not both.')
     parser.add_argument('--ami_ram', dest='ami_ram', required=False,
-                        help='If launching ec2 via AMI, use this to specify how much minimum RAM you want '
-                             '(default=%(default)s).')
+                        help='If launching ec2 via AMI, use this to specify '
+                             'how much minimum RAM you want (default=%(default)s).')
     parser.add_argument('--task_name', dest='task_name', required=False,
                         help='The name of the ecs task (default=%(default)s).')
     parser.add_argument('--ssh_keypath', dest='ssh_keypath', required=False,
@@ -114,8 +124,10 @@ def setup_arg_parsing():
                              'used for comms over ssh (default=%(default)s).')
     parser.add_argument('--pg_instance', dest='pg_instance', required=False,
                         help='Instance ID of the Postgres ec2 instance (default=%(default)s). '
-                             'If you want to use a running postgres instance, just specify the host (e.g. localhost). '
-                             'WARNING: assumes that if the string starts with "i-", then it is an Instance ID')
+                             'If you want to use a running postgres instance, '
+                             'just specify the host (e.g. localhost). WARNING: '
+                             'assumes that if the string starts with "i-", '
+                             'then it is an Instance ID')
 
     parser.add_argument('--logging', dest='logging', action='store_true', help='Turn logging on.')
 
@@ -124,7 +136,8 @@ def setup_arg_parsing():
     parser.set_defaults(port="8491")
     parser.set_defaults(ssh_port="22")
     parser.set_defaults(user="ec2-user")
-    parser.set_defaults(remote_variables_file="/home/ec2-user/agief-project/variables/variables-ec2.sh")
+    parser.set_defaults(remote_variables_file="/home/ec2-user/agief-project/"
+                                              "variables/variables-ec2.sh")
     parser.set_defaults(pg_instance="localhost")
     parser.set_defaults(task_name="mnist-spatial-task:10")
     parser.set_defaults(ssh_keypath=utils.filepath_from_env_variable(".ssh/ecs-key.pem", "HOME"))
@@ -135,6 +148,12 @@ def setup_arg_parsing():
 
 
 def check_args(args, compute_node):
+    """
+    Checks the arguments and ensures the required parameters are set
+
+    :param args: The commandline arguments
+    :param compute_node: The instance of the Compute class
+    """
     if args.amiid and args.instanceid:
         logging.error("Both the AMI ID and EC2 Instance ID have been specified."
                       " Use just one to specify how to get a running ec2 instance")
@@ -146,8 +165,8 @@ def check_args(args, compute_node):
         exit(1)
 
     if args.ssh_keypath and not compute_node.remote():
-        logging.warn("A keypath has been set, but we're not running on a "
-                     "remote machine (arg: step_remote). It will have no effect.")
+        logging.warning("A keypath has been set, but we're not running on a "
+                        "remote machine (arg: step_remote). It will have no effect.")
 
     if args.sync and not compute_node.remote():
         logging.error("Syncing experiment is meaningless unless you're running "
@@ -155,16 +174,16 @@ def check_args(args, compute_node):
         exit(1)
 
     if args.exps_file and not args.launch_compute:
-        logging.warn("You have elected to run experiment without launching a "
-                     "Compute node. For success, you'll have to have one "
-                     "running already, or use param --step_compute)")
+        logging.warning("You have elected to run experiment without launching a "
+                        "Compute node. For success, you'll have to have one "
+                        "running already, or use param --step_compute)")
 
 
+# pylint: disable=R0915, R0912, R0914
 def main():
-
-    # setup logging
-    log_format = "[%(filename)s:%(lineno)s - %(funcName)s() - %(levelname)s] %(message)s"
-    logging.basicConfig(format=log_format)
+    """
+    The main scope of the run-framework containing the high level code
+    """
 
     print("------------------------------------------")
     print("----          run-framework           ----")
@@ -174,12 +193,16 @@ def main():
     exp_start_time = datetime.now()
 
     args = setup_arg_parsing()
-    if args.logging:
-        logging.debug("Arguments: ", args)
-        logging.debug ("Python Version: " + sys.version)
+
+    # setup logging
+    log_format = "[%(filename)s:%(lineno)s - %(funcName)s() - %(levelname)s] %(message)s"
+    logging.basicConfig(format=log_format, level=utils.logger_level(args.logging))
+
+    logging.debug("Python Version: " + sys.version)
+    logging.debug("Arguments: %s", args)
 
     exps_file = args.exps_file if args.exps_file else ""
-    experiment = Experiment(args.logging, args.debug_no_run, LaunchMode.from_args(args), exps_file)
+    experiment = Experiment(args.debug_no_run, LaunchMode.from_args(args), exps_file)
 
     # 1) Generate input files
     if args.main_class:
@@ -191,14 +214,16 @@ def main():
 
     # *) all other use cases (non Generate input files)
 
-    cloud = Cloud(args.logging)
+    cloud = Cloud()
 
     if args.upload and not (args.export or args.export_compute):
-        logging.warning("Uploading experiment to S3 is enabled, but 'export experiment' is not, so the most "
-                        "important files (output entity.json and data.json) will be missing")
+        logging.warning("Uploading experiment to S3 is enabled, but "
+                        "'export experiment' is not, so the most important "
+                        "files (output entity.json and data.json) will be missing")
 
     if args.remote_type != "local":
-        host_node = HostNode(args.host, args.user, args.ssh_keypath, args.remote_variables_file, args.ssh_port)
+        host_node = HostNode(args.host, args.user, args.ssh_keypath,
+                             args.remote_variables_file, args.ssh_port)
     else:
         host_node = HostNode(args.host, args.user)
 
@@ -218,7 +243,9 @@ def main():
             ips = cloud.ec2_start_from_instanceid(args.instanceid)
             instance_id = args.instanceid
         else:
-            ips, instance_id = cloud.ec2_start_from_ami('run-fwk auto', args.amiid, int(args.ami_ram))
+            ips, instance_id = cloud.ec2_start_from_ami('run-fwk auto',
+                                                        args.amiid,
+                                                        int(args.ami_ram))
 
         # start DB ec2, from instanceid
         if args.pg_instance and is_pg_ec2:
@@ -228,7 +255,8 @@ def main():
 
     elif args.pg_instance:
         if is_pg_ec2:
-            logging.error("The pg instance is set to an ec2 instance id, but you are not running AWS.")
+            logging.error("The pg instance is set to an ec2 instance id,"
+                          " but you are not running AWS.")
             exit(1)
 
         ips_pg = {'ip_public': args.pg_instance, 'ip_private': args.pg_instance}
@@ -249,31 +277,34 @@ def main():
         if args.sync:
             cloud.sync_experiment(compute_node.host_node)
 
-        # 3.5) Sync data from S3 (typically used to download output files from a prev. experiment to be used as input)
+        # 3.5) Sync data from S3 (typically used to download output files
+        # from a prev. experiment to be used as input)
         if args.sync_s3_prefix:
             cloud.remote_download_output(args.sync_s3_prefix, compute_node.host_node)
 
         # 4) Launch Compute (remote or local) - *** IF Mode == 'Per Session' ***
         if (LaunchMode.from_args(args) is LaunchMode.per_session) and args.launch_compute:
-            compute_node.launch(experiment, cloud=cloud, main_class=args.main_class, no_local_docker=args.no_docker)
+            compute_node.launch(experiment, cloud=cloud,
+                                main_class=args.main_class,
+                                no_local_docker=args.no_docker)
 
         # 5) Run experiments (includes per experiment 'export results' and 'upload results')
         if args.exps_file:
             experiment.run_sweeps(compute_node, cloud, args)
             experiment.persist_prefix_history()
 
-    except Exception as e:
+    except Exception as err: # pylint: disable=W0703
         failed = True
 
-        logging.error("Something failed running sweeps generally. "
-                      "If the error occurred in a specific parameter set it should have been caught there. "
+        logging.error("Something failed running sweeps generally. If the error "
+                      "occurred in a specific parameter set it should have been caught there. "
                       "Attempt to shut down infrastructure if running, and exit.")
-        logging.error(e)
+        logging.error(err)
 
         # Shutdown the Docker container
         print("Attempting to shutdown Docker container...")
         if host_node.remote() and compute_node.container_id:
-            utils.remote_run(host_node, 'docker stop ' + compute_node.container_id, True)
+            utils.remote_run(host_node, 'docker stop ' + compute_node.container_id)
         elif not host_node.remote() and not args.no_docker:
             utils.docker_stop()
 

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -135,26 +135,28 @@ def setup_arg_parsing():
 
 def check_args(args, compute_node):
     if args.amiid and args.instanceid:
-        print("ERROR: Both the AMI ID and EC2 Instance ID have been specified. Use just one to specify how to get "
-              "a running ec2 instance")
+        logging.error("Both the AMI ID and EC2 Instance ID have been specified."
+                      " Use just one to specify how to get a running ec2 instance")
         exit(1)
 
     if not args.remote_type == "aws" and (args.amiid or args.instanceid):
-        print("ERROR: amiid or instanceid was specified, but AWS has not been set, so they have no effect.")
+        logging.error("amiid or instanceid was specified, but AWS has not been "
+                      "set, so they have no effect.")
         exit(1)
 
     if args.ssh_keypath and not compute_node.remote():
-        print("WARNING: a keypath has been set, but we're not running on a remote machine (arg: step_remote). "
-              "It will have no effect.")
+        logging.warn("A keypath has been set, but we're not running on a "
+                     "remote machine (arg: step_remote). It will have no effect.")
 
     if args.sync and not compute_node.remote():
-        print("ERROR: Syncing experiment is meaningless unless you're running on a "
-              "remote machine (use param --step_remote)")
+        logging.error("Syncing experiment is meaningless unless you're running "
+                      "on a remote machine (use param --step_remote)")
         exit(1)
 
     if args.exps_file and not args.launch_compute:
-        print("WARNING: You have elected to run experiment without launching a Compute node. For success, you'll "
-              "have to have one running already, or use param --step_compute)")
+        logging.warn("You have elected to run experiment without launching a "
+                     "Compute node. For success, you'll have to have one "
+                     "running already, or use param --step_compute)")
 
 
 def main():
@@ -165,9 +167,9 @@ def main():
     # logging.basicConfig(format=log_format)
     # logger.setLevel(logging.INFO)
 
-    print("------------------------------------------")
-    print("----          run-framework           ----")
-    print("------------------------------------------")
+    logging.info("------------------------------------------")
+    logging.info("----          run-framework           ----")
+    logging.info("------------------------------------------")
 
     # Record experiment start time
     exp_start_time = datetime.now()
@@ -269,7 +271,7 @@ def main():
         logging.error(e)
 
         # Shutdown the Docker container
-        print("Attempting to shutdown Docker container...")
+        logging.info("Attempting to shutdown Docker container...")
         if host_node.remote() and compute_node.container_id:
             utils.remote_run(host_node, 'docker stop ' + compute_node.container_id, True)
         elif not host_node.remote() and not args.no_docker:
@@ -290,9 +292,9 @@ def main():
     # Record experiment end time
     exp_end_time = datetime.now()
 
-    # Print the experiment runtime in d:h:m:s:ms format
+    # Log the experiment runtime in d:h:m:s:ms format
     exp_runtime = utils.format_timedelta(exp_end_time - exp_start_time)
-    print("Experiment finished in %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
+    logging.info("Experiment finished in %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
 
     if failed:
         exit(1)

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -163,8 +163,8 @@ def check_args(args, compute_node):
 def main():
 
     # setup logging
-    log_format = "[%(filename)s:%(lineno)s - %clas%(funcName)s() - %(levelname)s] %(message)s"
-    logging.basicConfig(format=log_format, level=logging.INFO)
+    log_format = "[%(filename)s:%(lineno)s - %(funcName)s() - %(levelname)s] %(message)s"
+    logging.basicConfig(format=log_format)
 
     print("------------------------------------------")
     print("----          run-framework           ----")


### PR DESCRIPTION
As per our discussions, we will be keeping the `print` statements instead of using `logging.info` to keep the console output nice and neat! 💃 

I have made some changes to update the remaining `print` statements with any `ERROR` or `WARNING` mentions to `logging.error` and `logging.warning` respectively.

**Format:** `[FILE_NAME:LINE_NUMBER - functionName() - LEVEL] MESSAGE`

**Example:** `[run-framework.py:149 - check_args() - WARNING] A keypath has been set, but we're not running on a remote machine (arg: step_remote). It will have no effect.`

There didn't seem to be an obvious way to include the class name it self, but the file name would be a good indication of the class anyway. Let me know if you would like to alter the message format!