### PR TITLE
Optional Compression and Improvements

### DIFF
--- a/scripts/remote/remote-download-output.sh
+++ b/scripts/remote/remote-download-output.sh
@@ -40,13 +40,18 @@ ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix
 	echo $cmd >> remote-download-cmd.log
 	eval $cmd >> remote-download-stdout.log 2>> remote-download-stderr.log
 
-	# matching_files=( $(find . -maxdepth 1 -name '*.zip') )
-	# unzip ${matching_files[0]} -d $download_folder
-	
-	if [ `uname` == 'Darwin' ]; then
-		unzip -o $download_folder/data.zip -d $download_folder
-	else
-		unzip -o $download_folder/data -d $download_folder
+	# find zip file in download folder
+	matching_files=( $(find $download_folder -maxdepth 1 -name '*.zip') )
+
+	# ensure file exists before unzipping
+	if [ ${matching_files[0]} ] && [ -f ${matching_files[0]} ]; then
+		if [ `uname` == 'Darwin' ]; then
+			unzip -o ${matching_files[0]} -d $download_folder
+		else
+			# unzip without .zip extension
+			# ref: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+			unzip -o ${matching_files[0]%.*} -d $download_folder
+		fi
 	fi
 ENDSSH
 

--- a/scripts/remote/remote-upload-output.sh
+++ b/scripts/remote/remote-upload-output.sh
@@ -33,7 +33,7 @@ ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix
 	upload_folder=$AGI_RUN_HOME/output/$prefix
 	echo "Calculated upload-folder = " $upload_folder
 
-	if [ ${no_compress} = False ]; then
+	if [ "$no_compress" == "False" ]; then
 		output_big_folder=$AGI_RUN_HOME/output-big/
 		mkdir -p $output_big_folder
 

--- a/scripts/remote/remote-upload-output.sh
+++ b/scripts/remote/remote-upload-output.sh
@@ -17,6 +17,7 @@ keyfile=${3:-$HOME/.ssh/ecs-key.pem}
 user=${4:-ec2-user}
 remote_variables_file=${5:-/home/ec2-user/agief-project/variables/variables-ec2.sh}
 port=${6:-22}
+no_compress=${7:False}
 
 echo "Using prefix = " $prefix
 echo "Using host = " $host
@@ -25,19 +26,21 @@ echo "Using user = " $user
 echo "Using remote_variables_file = " $remote_variables_file
 echo "Using port =  " $port
 
-ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix=$prefix VARIABLES_FILE=$remote_variables_file 'bash --login -s' <<'ENDSSH'
+ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix=$prefix VARIABLES_FILE=$remote_variables_file no_compress=$no_compress 'bash --login -s' <<'ENDSSH'
 	export VARIABLES_FILE=$VARIABLES_FILE
 	source $VARIABLES_FILE
 
 	upload_folder=$AGI_RUN_HOME/output/$prefix
 	echo "Calculated upload-folder = " $upload_folder
 
-	output_big_folder=$AGI_RUN_HOME/output-big/
-	mkdir -p $output_big_folder
+	if [ ${no_compress} = False ]; then
+		output_big_folder=$AGI_RUN_HOME/output-big/
+		mkdir -p $output_big_folder
 
-	matching_files=( $(find $upload_folder -name '*data*') )
-	zip -j $upload_folder/data.zip ${matching_files[0]}
-	mv ${matching_files[0]} $output_big_folder
+		matching_files=( $(find $upload_folder -name '*data*') )
+		zip -j $upload_folder/data.zip ${matching_files[0]}
+		mv ${matching_files[0]} $output_big_folder
+	fi
 
 	cmd="aws s3 cp $upload_folder s3://agief-project/experiment-output/$prefix/output --recursive"
 	echo $cmd >> remote-upload-cmd.log

--- a/scripts/remote/remote-upload-output.sh
+++ b/scripts/remote/remote-upload-output.sh
@@ -17,7 +17,7 @@ keyfile=${3:-$HOME/.ssh/ecs-key.pem}
 user=${4:-ec2-user}
 remote_variables_file=${5:-/home/ec2-user/agief-project/variables/variables-ec2.sh}
 port=${6:-22}
-no_compress=${7:False}
+no_compress=${7:-False}
 
 echo "Using prefix = " $prefix
 echo "Using host = " $host

--- a/scripts/remote/remote-upload-output.sh
+++ b/scripts/remote/remote-upload-output.sh
@@ -33,7 +33,7 @@ ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix
 	upload_folder=$AGI_RUN_HOME/output/$prefix
 	echo "Calculated upload-folder = " $upload_folder
 
-	if [ "$no_compress" == "False" ]; then
+	if [ "$no_compress" = "False" ]; then
 		output_big_folder=$AGI_RUN_HOME/output-big/
 		mkdir -p $output_big_folder
 

--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -241,8 +241,8 @@ class Cloud:
             logging.error("Remote Upload Failed for this file")
             logging.error("Exception: %s", e)
 
-    def remote_upload_output_s3(self, host_node, prefix):
-        cmd = "../remote/remote-upload-output.sh " + prefix + " " + host_node.host_key_user_variables()
+    def remote_upload_output_s3(self, host_node, prefix, no_compress):
+        cmd = "../remote/remote-upload-output.sh " + prefix + " " + host_node.host_key_user_variables() + " " + str(no_compress)
         utils.run_bashscript_repeat(cmd, 3, 3)
 
     def upload_folder_s3(self, bucket_name, key, source_folderpath):

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -24,10 +24,11 @@ class Experiment:
     TEMPLATE_PREFIX = "SPAGHETTI"
     PREFIX_DELIMITER = "--"
 
-    def __init__(self, debug_no_run, launch_mode, exps_file):
+    def __init__(self, debug_no_run, launch_mode, exps_file, no_compress):
         self.exps_file = exps_file
         self.debug_no_run = debug_no_run
         self.launch_mode = launch_mode
+        self.no_compress = no_compress
 
         self.experiment_utils = ExperimentUtils(exps_file)
 
@@ -431,9 +432,9 @@ class Experiment:
         if compute_node.remote() and export_compute:
             print "\n --- Upload from exported file on remote machine."
             # remote upload of /output/[prefix] folder
-            cloud.remote_upload_output_s3(compute_node.host_node, self.prefix())
+            cloud.remote_upload_output_s3(compute_node.host_node, self.prefix(), self.no_compress)
         # otherwise, upload it from here
-        else:
+        elif self.no_compress is False:
             folder_path_big = self.experiment_utils.runpath("output-big/")
 
             # locate the output data file

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -133,6 +133,9 @@ def setup_arg_parsing():
                         help='Logging level (default=%(default)s). '
                              'Options: debug, info, warning, error, critical')
 
+    parser.add_argument('--no_compress', dest='no_compress', action='store_true',
+                        help='If set, then DO NOT compress the experiment output data (default=%(default)s).')
+
     parser.set_defaults(remote_type="local")  # i.e. not remote
     parser.set_defaults(host="localhost")
     parser.set_defaults(port="8491")
@@ -146,6 +149,7 @@ def setup_arg_parsing():
     parser.set_defaults(ami_ram='6')
     parser.set_defaults(no_docker=False)
     parser.set_defaults(logging="warning")
+    parser.set_defaults(no_compress=False)
 
     return parser.parse_args()
 
@@ -205,7 +209,7 @@ def main():
     logging.debug("Arguments: %s", args)
 
     exps_file = args.exps_file if args.exps_file else ""
-    experiment = Experiment(args.debug_no_run, LaunchMode.from_args(args), exps_file)
+    experiment = Experiment(args.debug_no_run, LaunchMode.from_args(args), exps_file, args.no_compress)
 
     # 1) Generate input files
     if args.main_class:


### PR DESCRIPTION
- Updated `remote-download-output` script to match the correct zip file and check if it exists before the unzip process
- Added new optional parameter `no_compress` in run framework, defaults to `False` to enable an option to disable experiment output compression
    - Pass parameter to the python upload in Experiment class
    - Pass parameter to the `remote-upload-output` script