### PR TITLE
run-framework flag for disk persistence 

### DIFF
--- a/scripts/run-framework/agief_experiment/cloud.py
+++ b/scripts/run-framework/agief_experiment/cloud.py
@@ -241,8 +241,10 @@ class Cloud:
             logging.error("Remote Upload Failed for this file")
             logging.error("Exception: %s", e)
 
-    def remote_upload_output_s3(self, host_node, prefix, no_compress):
-        cmd = "../remote/remote-upload-output.sh " + prefix + " " + host_node.host_key_user_variables() + " " + str(no_compress)
+    def remote_upload_output_s3(self, host_node, prefix, no_compress, csv_output):
+        cmd = "../remote/remote-upload-output.sh " + prefix + " "
+        cmd += host_node.host_key_user_variables() + " "
+        cmd += str(no_compress) + " " + str(csv_output)
         utils.run_bashscript_repeat(cmd, 3, 3)
 
     def upload_folder_s3(self, bucket_name, key, source_folderpath):

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -137,6 +137,9 @@ def setup_arg_parsing():
     parser.add_argument('--no_compress', dest='no_compress', action='store_true',
                         help='If set, then DO NOT compress the experiment output data (default=%(default)s).')
 
+    parser.add_argument('--csv_output', dest='csv_output', action='store_true',
+                        help='If set, then output CSV files for features/labels (default=%(default)s).')
+
     parser.set_defaults(remote_type="local")  # i.e. not remote
     parser.set_defaults(host="localhost")
     parser.set_defaults(port="8491")
@@ -151,6 +154,7 @@ def setup_arg_parsing():
     parser.set_defaults(no_docker=False)
     parser.set_defaults(logging="warning")
     parser.set_defaults(no_compress=False)
+    parser.set_defaults(csv_output=False)
 
     return parser.parse_args()
 
@@ -210,7 +214,7 @@ def main():
     logging.debug("Arguments: %s", args)
 
     exps_file = args.exps_file if args.exps_file else ""
-    experiment = Experiment(args.debug_no_run, LaunchMode.from_args(args), exps_file, args.no_compress)
+    experiment = Experiment(args.debug_no_run, LaunchMode.from_args(args), exps_file, args.no_compress, args.csv_output)
 
     # 1) Generate input files
     if args.main_class:


### PR DESCRIPTION
**Highlights**
- Added new parameter for saving CSV that's turned off by default
- Updated the Experiment class to conditionally export the correct files
- Updated the remote upload script to utilise the new param

@affogato as discussed yesterday, are you happy with changing the flag name from `csv_output` to `disk_persistence`?