### PR TITLE
Capture Experiment Runtime during Parameter Sweeps

### DIFF
--- a/scripts/run-framework/agief_experiment/compute.py
+++ b/scripts/run-framework/agief_experiment/compute.py
@@ -21,6 +21,7 @@ class Compute:
         self.port = port
         self.host_node = host_node
         self.container_id = ''
+        self.runtime = 0
 
     def remote(self):
         return self.host_node.remote()
@@ -107,10 +108,9 @@ class Compute:
         print_age(i, age_string)
         print("   -> success, parameter reached value" + age_string)
 
-        # append & print param sweeps runtime
-        Experiment.append_runtime(runtime)
-        print("Parameter Sweeps finished in %d days, %d hr, %d min, " \
-              "%d s, %d ms." % tuple(run_time))
+        # set param sweeps runtime
+        if param_runtime > 0:
+            self.runtime = utils.format_runtime(param_runtime)
 
     def import_experiment(self, entity_filepath=None, data_filepaths=None):
         """setup the running instance of AGIEF with the input files"""

--- a/scripts/run-framework/agief_experiment/compute.py
+++ b/scripts/run-framework/agief_experiment/compute.py
@@ -52,6 +52,7 @@ class Compute:
         wait_period = 10
         age = None
         i = 0
+        param_runtime = 0
         connection_error_count = 0
 
         print("... Waiting for param to achieve value (try every " + str(wait_period) + "s): " + entity_name +
@@ -85,6 +86,7 @@ class Compute:
 
                 if 'value' in config:
                     age = dpath.util.get(config, 'value.age', '.')
+                    param_runtime = dpath.util.get(config, 'value.runTime', '.')
                     parameter = dpath.util.get(config, 'value.' + param_path, '.')
                     if parameter == value:
                         logging.debug(
@@ -104,6 +106,11 @@ class Compute:
         # successfully reached value
         print_age(i, age_string)
         print("   -> success, parameter reached value" + age_string)
+
+        # append & print param sweeps runtime
+        Experiment.append_runtime(runtime)
+        print("Parameter Sweeps finished in %d days, %d hr, %d min, " \
+              "%d s, %d ms." % tuple(run_time))
 
     def import_experiment(self, entity_filepath=None, data_filepaths=None):
         """setup the running instance of AGIEF with the input files"""

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -41,8 +41,6 @@ class Experiment:
         self.prefixes_history = ""
         self.prefix_modifier = ""
 
-        self.run_time = 0
-
     def reset_prefix(self):
 
         print("-------------- RESET_PREFIX -------------")
@@ -194,6 +192,9 @@ class Experiment:
 
             if not self.debug_no_run:
                 compute_node.run_experiment(self.entity_with_prefix("experiment"))
+                self.append_runtime(compute_node.runtime)
+                print("Parameter Sweeps finished in %d days, %d hr, %d min, " \
+                    "%d s." % tuple(compute_node.runtime))
 
             self.remember_prefix()
 
@@ -519,10 +520,8 @@ class Experiment:
         else:
             cloud.upload_folder_s3(bucket_name, key, source_path)
 
-    @staticmethod
-    def append_runtime(runtime):
-        formatted_runtime = utils.format_timedelta(runtime)
+    def append_runtime(self, runtime):
         info_filepath = self.experiment_utils.outputfile(self.prefix(), "experiment-info.txt")
 
         with open(info_filepath, 'a') as data:
-            data.write("\n\nExperiment Runtime: %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
+            data.write("\n\nExperiment Runtime: %d days, %d hr, %d min, %d s." % tuple(runtime))

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -194,7 +194,7 @@ class Experiment:
                 compute_node.run_experiment(self.entity_with_prefix("experiment"))
                 self.append_runtime(compute_node.runtime)
                 print("Parameter Sweeps finished in %d days, %d hr, %d min, " \
-                    "%d s." % tuple(compute_node.runtime))
+                    "%d s" % tuple(compute_node.runtime))
 
             self.remember_prefix()
 
@@ -524,4 +524,4 @@ class Experiment:
         info_filepath = self.experiment_utils.outputfile(self.prefix(), "experiment-info.txt")
 
         with open(info_filepath, 'a') as data:
-            data.write("\n\nExperiment Runtime: %d days, %d hr, %d min, %d s." % tuple(runtime))
+            data.write("\nExperiment Runtime: %d days, %d hr, %d min, %d s" % tuple(runtime))

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -41,6 +41,8 @@ class Experiment:
         self.prefixes_history = ""
         self.prefix_modifier = ""
 
+        self.run_time = 0
+
     def reset_prefix(self):
 
         print("-------------- RESET_PREFIX -------------")
@@ -516,3 +518,11 @@ class Experiment:
             cloud.upload_file_s3(bucket_name, key, source_path)
         else:
             cloud.upload_folder_s3(bucket_name, key, source_path)
+
+    @staticmethod
+    def append_runtime(runtime):
+        formatted_runtime = utils.format_timedelta(runtime)
+        info_filepath = self.experiment_utils.outputfile(self.prefix(), "experiment-info.txt")
+
+        with open(info_filepath, 'a') as data:
+            data.write("\n\nExperiment Runtime: %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))

--- a/scripts/run-framework/agief_experiment/utils.py
+++ b/scripts/run-framework/agief_experiment/utils.py
@@ -8,6 +8,7 @@ import sys
 import time
 import logging
 import paramiko
+import datetime
 
 
 def restart_line():
@@ -229,7 +230,7 @@ def set_entityfile_config(entity, config):
         Get a valid json config string, and put it back in the exported entity in a way that can be Imported 
         i.e. with escape characters so that it is a dumb string
         
-        NOTE: Works with Import/Export API, which does not treat config string as a valid json string 
+        NOTE: Works with Import/Export API, which does not treat config string as a valid json string
     """
 
     # put the escape characters back in the config str and write back to file
@@ -242,10 +243,25 @@ def set_entityfile_config(entity, config):
 
 
 def format_timedelta(td):
-    hours = td.seconds // 3600
-    minutes = (td.seconds // 60) % 60
+    # Split td.seconds into minutes and seconds
+    m       = td.seconds / 60;
+    seconds = td.seconds % 60;
 
-    return td.days, hours, minutes, td.seconds, td.microseconds
+    # Split m into hours and minutes.
+    h       = m / 60;
+    minutes = m % 60;
+
+    # Split h into days and hours
+    days    = h / 24;
+    hours   = h % 24;
+
+    return days, hours, minutes, seconds
+
+
+def format_runtime(runtime):
+    td_runtime = datetime.timedelta(milliseconds=int(runtime))
+    formatted_runtime = format_timedelta(td_runtime)
+    return formatted_runtime
 
 
 def docker_id():

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -341,7 +341,7 @@ def main():
 
     # Log the experiment runtime in d:h:m:s:ms format
     exp_runtime = utils.format_timedelta(exp_end_time - exp_start_time)
-    print("Experiment finished in %d days, %d hr, %d min, %d s." % tuple(exp_runtime))
+    print("Experiment finished in %d days, %d hr, %d min, %d s" % tuple(exp_runtime))
 
     if failed:
         exit(1)

--- a/scripts/run-framework/run-framework.py
+++ b/scripts/run-framework/run-framework.py
@@ -341,7 +341,7 @@ def main():
 
     # Log the experiment runtime in d:h:m:s:ms format
     exp_runtime = utils.format_timedelta(exp_end_time - exp_start_time)
-    print("Experiment finished in %d days, %d hr, %d min, %d s, %d ms." % tuple(exp_runtime))
+    print("Experiment finished in %d days, %d hr, %d min, %d s." % tuple(exp_runtime))
 
     if failed:
         exit(1)


### PR DESCRIPTION
**Changes**
- Capture and save the `value.runTime` from Experiment Entity during the parameter sweeps
- Following experiment termination, print the runtime and append it to `experiment-info.txt`

Counterpart PR: https://github.com/ProjectAGI/agi/pull/37

**Sample Outputs**

Console
```
...
Try = [159], 171208-1809--experiment.age = 172103
   -> success, parameter reached value, 171208-1809--experiment.age = 172103
Parameter Sweeps finished in 0 days, 0 hr, 26 min, 15 s
...
```
experiment-info.txt
```
==============================================
Experiment Information
==============================================
Datetime: 17 12 08 - 18 09
Folder: /path/to/20171108-mnist-batchsparse/
Githash: 1466932

Variables file: /path/to/variables/variables.sh
Prefix: 171208-1809
==============================================

Sweep Parameters:
171208-1809--autoencoder.sparsity = 25
171208-1809--autoencoder.sparsityLifetime = 2
171208-1809--autoencoder.batchSize = 32
171208-1809--autoencoder.learningRate = 0.01
171208-1809--autoencoder.momentum = 0.9
171208-1809--autoencoder.weightsStdDev = 0.01
171208-1809--image-class.trainingEpochs = 1

Experiment Runtime: 0 days, 0 hr, 26 min, 15 s
```