### PR TITLE
Flush Old Logs

### DIFF
--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -28,6 +28,8 @@ class Experiment:
     LABELS_FILENAME = "labels"
     FEATURES_FILENAME = "features"
 
+    LOG_FILENAME = "log4j2.log"
+
     def __init__(self, debug_no_run, launch_mode, exps_file, no_compress, csv_output):
         self.exps_file = exps_file
         self.debug_no_run = debug_no_run
@@ -440,15 +442,13 @@ class Experiment:
                                     self.experiment_utils.experiment_def_file())
 
         # upload log4j configuration file that was used
-        log_filename = "log4j2.log"
-
         if compute_node.remote():
-            cloud.remote_upload_runfilename_s3(compute_node.host_node, self.prefix(), log_filename)
+            cloud.remote_upload_runfilename_s3(compute_node.host_node, self.prefix(), LOG_FILENAME)
         else:
-            log_filepath = self.experiment_utils.runpath(log_filename)
+            log_filepath = self.experiment_utils.runpath(LOG_FILENAME)
             self.upload_experiment_file(cloud,
                                         self.prefix(),
-                                        log_filename,
+                                        LOG_FILENAME,
                                         log_filepath)
 
         # upload /output files (entity.json, data.json and experiment-info.txt)

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -172,6 +172,9 @@ class Experiment:
         with open(info_filepath, 'w') as data:
             data.write(info)
 
+        # Silently remove older log file if exists
+        utils.remove_file(LOG_FILENAME, True)
+
         failed = False
         task_arn = None
         try:

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -3,6 +3,7 @@ import functools
 import json
 import os
 import logging
+import time
 
 
 import dpath
@@ -173,7 +174,11 @@ class Experiment:
             data.write(info)
 
         # Silently remove older log file if exists
-        utils.remove_file(LOG_FILENAME, True)
+        log_filepath = self.experiment_utils.runpath(self.LOG_FILENAME)
+        if compute_node.remote():
+             utils.remote_run(compute_node.host_node, 'rm ' + log_filepath)
+        else:
+            utils.remove_file(log_filepath, True)
 
         failed = False
         task_arn = None
@@ -446,12 +451,12 @@ class Experiment:
 
         # upload log4j configuration file that was used
         if compute_node.remote():
-            cloud.remote_upload_runfilename_s3(compute_node.host_node, self.prefix(), LOG_FILENAME)
+            cloud.remote_upload_runfilename_s3(compute_node.host_node, self.prefix(), self.LOG_FILENAME)
         else:
-            log_filepath = self.experiment_utils.runpath(LOG_FILENAME)
+            log_filepath = self.experiment_utils.runpath(self.LOG_FILENAME)
             self.upload_experiment_file(cloud,
                                         self.prefix(),
-                                        LOG_FILENAME,
+                                        self.LOG_FILENAME,
                                         log_filepath)
 
         # upload /output files (entity.json, data.json and experiment-info.txt)

--- a/scripts/run-framework/agief_experiment/utils.py
+++ b/scripts/run-framework/agief_experiment/utils.py
@@ -209,8 +209,24 @@ def move_file(source_filepath, dest_path, create_dest=False):
         logging.error("the source file path is not valid: " + source_filepath)
 
 
+def remove_file(source_filepath, silent=False):
+    """
+    Removes a file using the default os.remove method with the option for
+    silent removal to avoid raising errors when the file is not found.
+    :param source_filepath: the path to the file that needs to be removed
+    :param silent: (optional) if True, no error will be raised if file not found
+    :return:
+    """
+    try:
+        os.remove(source_filepath)
+    except OSError as e:
+        # Raise error if not silent, or if error not file not found
+        if not silent or e.errno != errno.ENOENT:
+            raise
+
+
 def get_entityfile_config(entity):
-    """ 
+    """
         Get the config field straight out of an exported Entity, and turn it into valid JSON 
         NOTE: Works with Import/Export API, which does not treat config string as a valid json string
     """


### PR DESCRIPTION
- Moved log filename to `LOG_FILENAME` constant in the Experiment class
- Added a simple `remove_file` method to utils with the option to silently remove a file (i.e. no exception raised if the file was not found)
- Remove the `log4j2.log` at the start of the experiment if it exists already to give the new experiment a blank slate for logging