### PR TITLE
Upload Prefixes

### DIFF
--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -30,6 +30,7 @@ class Experiment:
     FEATURES_FILENAME = "features"
 
     LOG_FILENAME = "log4j2.log"
+    PREFIXES_FILENAME = "prefixes.txt"
 
     def __init__(self, debug_no_run, launch_mode, exps_file, no_compress, csv_output):
         self.exps_file = exps_file
@@ -74,7 +75,7 @@ class Experiment:
     def remember_prefix(self):
         self.prefixes_history += self.prefix() + "\n"
 
-    def persist_prefix_history(self, filename="prefixes.txt"):
+    def persist_prefix_history(self, filename=PREFIXES_FILENAME):
         """ Save prefix history to a file """
 
         print("\n....... Save prefix history to " + filename)

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -450,6 +450,12 @@ class Experiment:
                                     self.experiment_utils.experiments_def_filename,
                                     self.experiment_utils.experiment_def_file())
 
+        # upload prefixes file
+        prefixes_filepath = self.experiment_utils.runpath(self.PREFIXES_FILENAME)
+        self.upload_experiment_file(cloud, self.prefix(),
+                                           self.PREFIXES_FILENAME,
+                                           prefixes_filepath)
+
         # upload log4j configuration file that was used
         if compute_node.remote():
             cloud.remote_upload_runfilename_s3(compute_node.host_node, self.prefix(), self.LOG_FILENAME)

--- a/scripts/run-framework/agief_experiment/experiment.py
+++ b/scripts/run-framework/agief_experiment/experiment.py
@@ -82,6 +82,12 @@ class Experiment:
         with open(filename, "w") as prefix_file:
             prefix_file.write(self.prefixes_history)
 
+        # Upload prefix history to S3
+        prefixes_filepath = self.experiment_utils.runpath(self.PREFIXES_FILENAME)
+        self.upload_experiment_file(cloud, self.prefix(),
+                                           self.PREFIXES_FILENAME,
+                                           prefixes_filepath)
+
     def info(self, sweep_param_vals):
 
         message = ""
@@ -449,12 +455,6 @@ class Experiment:
                                     self.prefix(),
                                     self.experiment_utils.experiments_def_filename,
                                     self.experiment_utils.experiment_def_file())
-
-        # upload prefixes file
-        prefixes_filepath = self.experiment_utils.runpath(self.PREFIXES_FILENAME)
-        self.upload_experiment_file(cloud, self.prefix(),
-                                           self.PREFIXES_FILENAME,
-                                           prefixes_filepath)
 
         # upload log4j configuration file that was used
         if compute_node.remote():


### PR DESCRIPTION
- Define `prefixes.txt` in a class constant for easier access
- Upload the `prefixes.txt` directly after writing to filesystem