### PR TITLE
Update remote-download-output script

### DIFF
--- a/scripts/remote/remote-download-output.sh
+++ b/scripts/remote/remote-download-output.sh
@@ -32,13 +32,17 @@ ssh -v -p $port -i $keyfile ${user}@${host} -o 'StrictHostKeyChecking no' prefix
 	download_folder=$AGI_RUN_HOME/output/$prefix
 	echo "Calculated download-folder = " $download_folder
 
-	# create folder if it doesn't exist
-	mkdir -p $download_folder
+	# Sync with S3 only if the directory is empty or non-existent
+	# ref: https://stackoverflow.com/q/20456666/
+	if ! find "$download_folder" -mindepth 1 -print -quit | grep -q .; then
+		# create folder if it doesn't exist
+		mkdir -p $download_folder
 
-	cmd="aws s3 cp s3://agief-project/experiment-output/$prefix/output $download_folder --recursive"
+		cmd="aws s3 cp s3://agief-project/experiment-output/$prefix/output $download_folder --recursive"
 
-	echo $cmd >> remote-download-cmd.log
-	eval $cmd >> remote-download-stdout.log 2>> remote-download-stderr.log
+		echo $cmd >> remote-download-cmd.log
+		eval $cmd >> remote-download-stdout.log 2>> remote-download-stderr.log
+	fi
 
 	# find zip file in download folder
 	matching_files=( $(find $download_folder -maxdepth 1 -name '*.zip') )


### PR DESCRIPTION
The `remote-download-output` script now only syncs the prefix folder with S3 if the directory does not exist or is empty. The script will uncompress and prepare the data as usual.

This will allow us to use the same script to prepare the data before Phase 2 without duplicating any code, and without unnecessarily syncing data if the Phase 1 output is already on that particular machine.

I'd like to update the argument name `step_sync_s3_prefix` to something else that describes it better.